### PR TITLE
chore: persist session permission grants to opencode.json

### DIFF
--- a/opencode.json
+++ b/opencode.json
@@ -5,15 +5,55 @@
   "permission": {
     "bash": {
       "*": "allow",
+
+      "cat *": "allow",
+      "ls *": "allow",
+      "echo *": "allow",
+      "head *": "allow",
+      "tail *": "allow",
+      "find *": "allow",
+      "wc *": "allow",
+      "sort *": "allow",
+      "uniq *": "allow",
+      "comm *": "allow",
+      "diff *": "allow",
+      "tr *": "allow",
+      "awk *": "allow",
+      "sed *": "allow",
+      "stat *": "allow",
+      "date *": "allow",
+      "sleep *": "allow",
+      "xargs *": "allow",
+      "env *": "allow",
+      "jq *": "allow",
+      "sh *": "allow",
+      "mkdir *": "allow",
+      "whoami": "allow",
+      "id": "allow",
+      "true": "allow",
+
+      "python3 *": "allow",
+      "curl *": "allow",
+
+      "git status *": "allow",
       "git diff *": "allow",
       "git log *": "allow",
-      "git status *": "allow",
+      "git show *": "allow",
+      "git fetch *": "allow",
+      "git pull *": "allow",
       "git add *": "allow",
       "git commit *": "allow",
-      "git push *": "ask",
       "git checkout *": "allow",
       "git branch *": "allow",
+      "git remote *": "allow",
+      "git cherry-pick *": "allow",
+      "git merge-base *": "allow",
+      "git submodule *": "allow",
+
+      "gh *": "allow",
+
       "docker *": "allow",
+
       "go build *": "allow",
       "go test *": "allow",
       "go get *": "allow",
@@ -21,13 +61,12 @@
       "go vet *": "allow",
       "go clean *": "allow",
       "gofmt *": "allow",
-      "mkdir *": "allow",
-      "find *": "allow",
-      "sh *": "allow",
-      "cat *": "allow",
-      "ls *": "allow",
-      "echo *": "allow",
+
+      "git push *": "ask",
       "rm *": "ask"
+    },
+    "external_directory": {
+      "/opt/docker/**": "allow"
     },
     "edit": "allow",
     "write": "allow",
@@ -36,6 +75,8 @@
     "grep": "allow",
     "task": "allow",
     "webfetch": "allow",
-    "question": "allow"
+    "websearch": "allow",
+    "question": "allow",
+    "skill": "allow"
   }
 }

--- a/opencode.json
+++ b/opencode.json
@@ -25,6 +25,7 @@
       "sleep *": "allow",
       "xargs *": "allow",
       "env *": "allow",
+      "timeout *": "allow",
       "jq *": "allow",
       "sh *": "allow",
       "mkdir *": "allow",


### PR DESCRIPTION
## Summary

Persists the effective permission set from the OTel deployment session into the project's `opencode.json`, so future sessions don't re-prompt for the same operations. Session-scoped "always" grants live in memory only and are lost on exit — this makes them durable.

## Changes

- **Explicit bash allows** for everything exercised during the OTel implementation + deployment debugging sessions:
  - `gh`, `curl`, `python3`, `sed`
  - coreutils: `stat`, `comm`, `sort`, `uniq`, `wc`, `diff`, `sleep`, `date`, `xargs`, `env`, `head`, `tail`, `jq`, `tr`, `awk`
  - additional git subcommands: `fetch`, `pull`, `show`, `cherry-pick`, `merge-base`, `remote`, `submodule`
- **`external_directory`: allow `/opt/docker/**`** — the live deployment tree (compose files, postmanpat configs) that this project's deployment work touches constantly. Defaults to `ask` otherwise.
- **Allow `websearch` and `skill` tools** (used via superpowers skills)
- Safety rails unchanged: `git push *` and `rm *` remain `ask`; top-level `"*": "allow"` default kept

## Notes

- Verified the opencode session DB (`~/.local/share/opencode/opencode.db`, `permission` table) holds no persisted grants — everything was in-memory, so this list was built from the session's actual command history.
- JSON validated with `python3 -m json.tool`.